### PR TITLE
fix: graphql value with `,`

### DIFF
--- a/generator.go
+++ b/generator.go
@@ -89,8 +89,7 @@ func generateForStruct(w io.Writer, v reflect.Type, indentLevel int, indent, jso
 		if !field.IsExported() {
 			continue
 		}
-		graphQLTag := field.Tag.Get(*graphQLTagName)
-		name, _, _ := strings.Cut(graphQLTag, ",")
+		name := field.Tag.Get(*graphQLTagName)
 		if name == "-" {
 			firstLine++
 			continue


### PR DESCRIPTION
## Description

## Problem
When the `graphql` tag contains a `,` The query gets broken.

## Solution
Remove old code that had the ability for options

## Notes
Other notes that you want to share but do not fit into _Problem_ or _Solution_.

